### PR TITLE
Add instructions to install Vagrant in Leap 15.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "data", "/vagrant_data", type: "rsync"
+  # config.vm.synced_folder "data", "/vagrant_data", type: "rsync"
   config.vm.synced_folder 'common', '/vagrant_common', type: "rsync"
 
   # Setup a private network as public, with default devstack address

--- a/common/local.confs/local.conf.sfc.compute
+++ b/common/local.confs/local.conf.sfc.compute
@@ -1,6 +1,6 @@
 [[local|localrc]]
 
-enable_plugin networking-sfc https://github.com/jcaamano/networking-sfc.git stable/queens_fixes
+enable_plugin networking-sfc https://github.com/openstack/networking-sfc stable/rocky
 
 NOVA_READY_TIMEOUT=600
 

--- a/common/local.confs/local.conf.sfc.controller
+++ b/common/local.confs/local.conf.sfc.controller
@@ -1,6 +1,6 @@
 [[local|localrc]]
 
-enable_plugin networking-sfc https://github.com/jcaamano/networking-sfc.git stable/queens_fixes
+enable_plugin networking-sfc https://github.com/openstack/networking-sfc stable/rocky
 
 Q_USE_PROVIDERNET_FOR_PUBLIC=True
 Q_ASSIGN_GATEWAY_TO_PUBLIC_BRIDGE=False

--- a/directory.conf.yml.sfc.opensuse.sample
+++ b/directory.conf.yml.sfc.opensuse.sample
@@ -1,0 +1,32 @@
+machines:
+  - name: controller
+    hypervisor:
+      name: localhost
+      username: jcaamano
+    memory: 8192
+    vcpus: 1
+    box: "opensuse/openSUSE-42.3-x86_64"
+    local_conf_file: ../common/local.confs/local.conf.sfc.controller
+    devstack_version: stable/rocky
+    projects:
+    - name: openvswitch
+      repo: https://github.com/jcaamano/ovs.git
+      version: fix_push_pop_eth
+    - name: openstack-scripts
+      repo: https://github.com/jcaamano/openstack-scripts.git
+
+  - name: compute
+    hypervisor:
+      name: localhost
+      username: jcaamano
+    memory: 8192
+    vcpus: 1
+    box: "opensuse/openSUSE-42.3-x86_64"
+    local_conf_file: ../common/local.confs/local.conf.sfc.compute
+    devstack_version: stable/rocky
+    projects:
+    - name: openvswitch
+      repo: https://github.com/jcaamano/ovs.git
+      version: fix_push_pop_eth
+    - name: openstack-scripts
+      repo: https://github.com/jcaamano/openstack-scripts.git

--- a/playbooks/ansible-setup.yml
+++ b/playbooks/ansible-setup.yml
@@ -12,6 +12,11 @@
     become: yes
     become_user: root
     ignore_errors: yes
+  - name: Install dependencies (opensuse)
+    raw: zypper -n install python
+    become: yes
+    become_user: root
+    ignore_errors: yes
   - name: setup
     setup:
   - name: Install python-selinux (RedHat)

--- a/playbooks/stack-user.yml
+++ b/playbooks/stack-user.yml
@@ -9,6 +9,12 @@
       shell: "/bin/bash"
     become: yes
     become_user: root
+  - name: Ensure group "stack" exists
+    group:
+      name: stack
+      state: present
+    become: yes
+    become_user: root
   - name: Add Stack to Sudoers
     lineinfile: dest=/etc/sudoers.d/stack line="stack ALL=(ALL) NOPASSWD:ALL" state=present create=yes
     become: yes

--- a/playbooks/stack-user.yml
+++ b/playbooks/stack-user.yml
@@ -23,10 +23,12 @@
     copy: src="~/.bashrc" dest=/home/stack/.bashrc
     become: yes
     become_user: stack
+    ignore_errors: yes
   - name: Install .gitconfig
     copy: src="~/.gitconfig" dest=/home/stack/.gitconfig
     become: yes
     become_user: stack
+    ignore_errors: yes
   - name: Test if custom .tmux.conf exist
     stat: path="~/.tmux.conf"
     register: tmux_conf_stat

--- a/readme.md
+++ b/readme.md
@@ -92,3 +92,13 @@ sudo zypper -n in libvirt-devel ruby-devel gcc
 
 4 - Install the vagrant-libvirt plugin:
 vagrant plugin install vagrant-libvirt
+<<<<<<< HEAD
+
+5 - Add the user to the libvirt group
+sudo usermod -a -G libvirt user_name
+
+6 - Start libirt daemon
+systemctl enable libvirtd
+systemctl start libvirtd
+=======
+>>>>>>> 0d1207a096d597e74c8aa1d1580f38ede0e0d577

--- a/readme.md
+++ b/readme.md
@@ -75,3 +75,20 @@ point.
 
 The virtual machine is provisioned using the `devstack.yml` ansible playbook.
 The playbooks used are available in the playbooks folder.
+
+
+## Install Vagrant in opensuse and vagrant-libvirt
+
+These steps describe how to install Vagrant for opensuse Leap 15.0
+
+1 - Add the vagrant repo:
+zypper addrepo https://download.opensuse.org/repositories/home:/pavlix:/Development/openSUSE_Leap_15.0/home:pavlix:Development.repo
+
+2 - Install vagrant:
+sudo zypper in vagrant
+
+3 - Install libvirt-devel, ruby-devel and gcc:
+sudo zypper -n in libvirt-devel ruby-devel gcc
+
+4 - Install the vagrant-libvirt plugin:
+vagrant plugin install vagrant-libvirt

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ and then run devstack.
 3. (Optional) Install an SSH public key in common/keys/id_rsa.pub
 4. Create a local.conf file (Or use some of the examples in common/local.confs)
 5. Add (or update) a machine in directory.conf.yml (See configuration below)
-6. Run: `vagrant up <machine name>`
+6. Run: `vagrant up <machine name>` or `vagrant up` to start both controller and compute
 
 Once the VM is set up, it can be accessed using `vagrant ssh -p --
 -l stack`.  Other SSH options may follow if desired. devstack will be

--- a/readme.md
+++ b/readme.md
@@ -108,4 +108,4 @@ sudo zypper install ansible
 ## Start using openstack
 
 vagrant ssh controller
-source /home/stack/devstack/openrc
+source /home/stack/devstack/openrc admin admin

--- a/readme.md
+++ b/readme.md
@@ -100,5 +100,6 @@ sudo usermod -a -G libvirt user_name
 6 - Start libirt daemon
 systemctl enable libvirtd
 systemctl start libvirtd
-=======
->>>>>>> 0d1207a096d597e74c8aa1d1580f38ede0e0d577
+
+7 - Install ansible
+sudo zypper install ansible

--- a/readme.md
+++ b/readme.md
@@ -103,3 +103,9 @@ systemctl start libvirtd
 
 7 - Install ansible
 sudo zypper install ansible
+
+
+## Start using openstack
+
+vagrant ssh controller
+source /home/stack/devstack/openrc

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ sudo zypper install ansible
 Once the compute is up, remember to discover it by executing in the controller:
 
 vagrant ssh controller
+
 ./home/stack/devstack/tools/discover_hosts.sh
 
 Then, to start using openstack:

--- a/readme.md
+++ b/readme.md
@@ -107,5 +107,11 @@ sudo zypper install ansible
 
 ## Start using openstack
 
+Once the compute is up, remember to discover it by executing in the controller:
+
 vagrant ssh controller
+./home/stack/devstack/tools/discover_hosts.sh
+
+Then, to start using openstack:
+
 source /home/stack/devstack/openrc admin admin


### PR DESCRIPTION
The process to install Vagrant in opensuse Leap 15.0 is convoluted.
Adding the steps to follow could help others

Signed-off-by: Manuel Buil <mbuil@suse.com>